### PR TITLE
Added sensor-specific current profiling option

### DIFF
--- a/src/dsros_dvl_plugin.hh
+++ b/src/dsros_dvl_plugin.hh
@@ -121,6 +121,7 @@ private:
   double gaussian_noise_range;
   bool water_track_enabled;
   int water_track_bins;
+  int current_profile_coord_mode;
   double current_profile_cell_depth;
   double current_profile_bin0_distance;
 };


### PR DESCRIPTION
Added instrument-relative current profile reporting option.  The default is still beam-specific reporting, but the new mode can be selected by setting value of the model's "currentProfileCoordMode" element to 1.