### PR TITLE
Install libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,12 @@ catkin_package(
   DEPENDS
 )
 
+install(TARGETS ds_sim_gazebo_msgs dsros_jointstate_publisher dsros_navstate_publisher dsros_sensors dsros_ros_depth dsros_ros_ins dsros_ros_dvl dsros_ros_gps dsros_ros_reson dsros_hydro dsros_ros_thruster
+  DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
 ## Install project namespaced headers
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}


### PR DESCRIPTION
In the course of rebasing the `glider_hybrid_whoi` repo to the latest dave version (ROS Noetic / Gazebo 11), the docker environment I am using with WHOI folks required the actual installation of the libraries. 

The modification installs the library so that it can be found.

Made this PR so that the changes can be shared with others. Please note that at `ds_msgs` repo, https://github.com/Field-Robotics-Lab/ds_msgs/commit/179631d46871b31fad28a21f81d865e3c73446d3 is made to fix the `catkin_make install` error