### PR TITLE
Fix dependency for catkin build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,8 +86,8 @@ set(SENSORS_SRCS
 # dsros_sensors (passed at STARTUP as a system plugin)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GAZEBO_CXX_FLAGS}")
 add_library(dsros_sensors ${SENSORS_SRCS})
-target_link_libraries(dsros_sensors ds_sim_gazebo_msgs dave_gazebo_world_plugins_msgs ${GAZEBO_LIBRARIES})
-add_dependencies(dsros_sensors ds_sim_gazebo_msgs dave_gazebo_world_plugins_msgs)
+target_link_libraries(dsros_sensors ds_sim_gazebo_msgs ${GAZEBO_LIBRARIES})
+add_dependencies(dsros_sensors ds_sim_gazebo_msgs)
 
 # dsros_ros_depth
 add_library(dsros_ros_depth src/dsros_depth_plugin.cc src/dsros_depth_plugin.hh)
@@ -101,8 +101,8 @@ add_dependencies(dsros_ros_ins ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPO
 
 # DVL plugin
 add_library(dsros_ros_dvl src/dsros_dvl_plugin.cc src/dsros_dvl_plugin.hh)
-target_link_libraries(dsros_ros_dvl dsros_sensors dave_gazebo_world_plugins_msgs ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES})
-add_dependencies(dsros_ros_dvl dave_gazebo_world_plugins_msgs ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+target_link_libraries(dsros_ros_dvl dsros_sensors ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES})
+add_dependencies(dsros_ros_dvl ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 # GPS plugin
 add_library(dsros_ros_gps src/dsros_gps_plugin.cc src/dsros_gps_plugin.hh)
@@ -132,6 +132,7 @@ catkin_package(
   INCLUDE_DIRS include
   #LIBRARIES ds_sim_gazebo_msgs  dsros_jointstate_publisher dsros_sensors dsros_ros_depth dsros_ros_ins dsros_ros_dvl dsros_ros_gps
   CATKIN_DEPENDS xacro roscpp gazebo_ros sensor_msgs ds_core_msgs ds_sensor_msgs ds_actuator_msgs ds_multibeam_msgs
+    dave_gazebo_world_plugins
   DEPENDS
 )
 


### PR DESCRIPTION
Addresses https://github.com/Field-Robotics-Lab/dave/issues/148

Turns out, this is all the fix that's needed, for the compiler error about not finding `-ldave_gazebo_world_plugins_msgs`.
Adding the package to `catkin_package(CATKIN_DEPENDS)` adds all the libraries to `${catkin_*}`, so the protobuf dependency is already covered.
`dsros_ros_dvl` is the only target that uses it; dsros_sensors is not using it.

To test:
```
catkin build
```

This should still work:
```
catkin_make
```