### PR TITLE
dsros_sensors: depend on dave_gazebo_world_plugins and export library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,11 +53,10 @@ endforeach()
 
 catkin_package(
   INCLUDE_DIRS include
-  #LIBRARIES ds_sim_gazebo_msgs dsros_jointstate_publisher dsros_ros_depth dsros_ros_ins dsros_ros_dvl dsros_ros_gps
-  LIBRARIES dsros_sensors
+  # Export for downstream packages
+  LIBRARIES ds_sim_gazebo_msgs dsros_jointstate_publisher dsros_ros_depth dsros_ros_ins dsros_ros_dvl dsros_ros_gps
   CATKIN_DEPENDS xacro roscpp gazebo_ros sensor_msgs ds_core_msgs ds_sensor_msgs ds_actuator_msgs ds_multibeam_msgs
     dave_gazebo_world_plugins
-  DEPENDS
 )
 
 # Build any protobuf messages we're going to use

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,15 @@ foreach(ITR ${GAZEBO_INCLUDE_DIRS})
   endif()
 endforeach()
 
+catkin_package(
+  INCLUDE_DIRS include
+  #LIBRARIES ds_sim_gazebo_msgs dsros_jointstate_publisher dsros_ros_depth dsros_ros_ins dsros_ros_dvl dsros_ros_gps
+  LIBRARIES dsros_sensors
+  CATKIN_DEPENDS xacro roscpp gazebo_ros sensor_msgs ds_core_msgs ds_sensor_msgs ds_actuator_msgs ds_multibeam_msgs
+    dave_gazebo_world_plugins
+  DEPENDS
+)
+
 # Build any protobuf messages we're going to use
 set (gazebo_msgs
   gazebo_msgs/SensorDepth.proto
@@ -85,8 +94,8 @@ set(SENSORS_SRCS
 
 # dsros_sensors (passed at STARTUP as a system plugin)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GAZEBO_CXX_FLAGS}")
-add_library(dsros_sensors ${SENSORS_SRCS})
-target_link_libraries(dsros_sensors ds_sim_gazebo_msgs ${GAZEBO_LIBRARIES})
+add_library(dsros_sensors SHARED ${SENSORS_SRCS})
+target_link_libraries(dsros_sensors ds_sim_gazebo_msgs ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES})
 add_dependencies(dsros_sensors ds_sim_gazebo_msgs)
 
 # dsros_ros_depth
@@ -127,14 +136,6 @@ add_dependencies(dsros_ros_thruster ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin
 #add_library(dsros_spotlight gazebo_src/dsros_spotlight.cc gazebo_src/dsros_spotlight.h)
 #target_link_libraries(dsros_spotlight ds_sim_gazebo_msgs  ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES})
 #add_dependencies(dsros_spotlight ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-catkin_package(
-  INCLUDE_DIRS include
-  #LIBRARIES ds_sim_gazebo_msgs  dsros_jointstate_publisher dsros_sensors dsros_ros_depth dsros_ros_ins dsros_ros_dvl dsros_ros_gps
-  CATKIN_DEPENDS xacro roscpp gazebo_ros sensor_msgs ds_core_msgs ds_sensor_msgs ds_actuator_msgs ds_multibeam_msgs
-    dave_gazebo_world_plugins
-  DEPENDS
-)
 
 install(TARGETS ds_sim_gazebo_msgs dsros_jointstate_publisher dsros_navstate_publisher dsros_sensors dsros_ros_depth dsros_ros_ins dsros_ros_dvl dsros_ros_gps dsros_ros_reson dsros_hydro dsros_ros_thruster
   DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,8 +148,3 @@ install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
   FILES_MATCHING PATTERN "*.h"
   PATTERN ".svn" EXCLUDE)
-
-include_directories(
-# include
-  ${catkin_INCLUDE_DIRS}
-)

--- a/gazebo_src/dsros_dvl.hh
+++ b/gazebo_src/dsros_dvl.hh
@@ -57,7 +57,7 @@
 #include <gazebo/common/common.hh>
 
 #include <SensorDvl.pb.h>
-#include <StratifiedCurrentVelocity.pb.h>
+#include <dave_gazebo_world_plugins/StratifiedCurrentVelocity.pb.h>
 
 namespace gazebo {
 namespace sensors {

--- a/package.xml
+++ b/package.xml
@@ -9,7 +9,7 @@
   <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
   <license>BSD</license>
 
-  <url type="repository">https://bitbucket.org/whoidsl/ds_sim</url> -->
+  <url type="repository">https://bitbucket.org/whoidsl/ds_sim</url>
 
   <author email="ivaughn@whoi.edu">Ian Vaughn</author>
   <author email="ssuman@whoi.edu">Stefano Suman</author>


### PR DESCRIPTION
Followup to the error in https://github.com/Field-Robotics-Lab/ds_sim/pull/5#issuecomment-1000125169
Depends on https://github.com/Field-Robotics-Lab/dave/pull/179

- Move `catkin_package()` up because according to http://wiki.ros.org/catkin/CMakeLists.txt , it must be called before any `add_library` and `add_executable`.
- Add `catkin_package(LIBRARIES dsros_sensors)`. This exports `dsros_sensors` library for downstream packages (`glider_hybrid_whoi_gazebo` for example) that depend on `ds_sim`. Make `dsros_sensors` `SHARED`.
- Add `${catkin_LIBRARIES}` dependency to `dsros_sensors` target. This gives `dsros_sensors` access to `dave_gazebo_world_plugins` which has been added to `catkin_package(CATKIN_DEPENDS)`. That is where symbol `StratifiedCurrentVelocity` is defined in a protobuf message.

Essentially, what these two PRs do is that they export `dave_gazebo_world_plugins` and `ds_sim` for downstream libraries, and links them together.

With these, I don't get that error anymore.

However, the manual `-s libdsros_sensors.so` flag in the `glider_hybrid_whoi_gazebo` launch files is still needed. It shouldn't be needed if things are set up correctly. I didn't try to track down where the launch file eventually leads to `dsros_sensors`. It isn't apparent to me from looking at the world files. Do we know where exactly the sensors are used in the glider worlds?
If we want to fix it, it would be in a separate PR. This PR is ready.