### PR TITLE
Fix install path

### DIFF
--- a/gazebo_src/dsros_dvl.hh
+++ b/gazebo_src/dsros_dvl.hh
@@ -57,7 +57,7 @@
 #include <gazebo/common/common.hh>
 
 #include <SensorDvl.pb.h>
-#include <dave_gazebo_world_plugins/StratifiedCurrentVelocity.pb.h>
+#include <StratifiedCurrentVelocity.pb.h>
 
 namespace gazebo {
 namespace sensors {


### PR DESCRIPTION
@mabelzhang I tried compiling with both catkin build and catkin_make - both can find the file *without* the full path but fail if the dave_gazebo_world_plugin prefix is present.  Is this working differently for you?